### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,4 +1,6 @@
 name: Build, e2e, and deploy
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/ctk-build/security/code-scanning/3](https://github.com/childmindresearch/ctk-build/security/code-scanning/3)

To address this, add an explicit `permissions` block to the workflow. The most secure approach is to add it at the workflow (top) level, immediately after the workflow name and before the `on:` block. This ensures all jobs and steps inherit the minimal permissions unless overridden.  
Since the jobs do not push commits, manipulate issues, or do anything that requires more than read-only access, the block should set `contents: read`, which is the minimum for most workflows (and allows actions like git checkout to work).  
Edit `.github/workflows/build-and-deploy.yaml`, and directly after the workflow `name`, add:  
```yaml
permissions:
  contents: read
```
No further changes are needed unless individual jobs require one of the other permissions (e.g., `pull-requests: write`), which is not evident here.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
